### PR TITLE
Repackage to org.openhwgroup.corev.ide

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhwgroup.corev.ide.cdt.root</name>
+	<name>org.openhwgroup.corev.ide.root</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.openhwgroup.corev.ide.cdt</groupId>
-	<artifactId>org.openhwgroup.corev.ide.cdt.root</artifactId>
+	<groupId>org.openhwgroup.corev.ide</groupId>
+	<artifactId>org.openhwgroup.corev.ide.root</artifactId>
 	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>
-		<module>.\releng\org.openhwgroup.corev.ide.cdt.aggregator</module>
+		<module>.\releng\org.openhwgroup.corev.ide.aggregator</module>
 	</modules>
 
 </project>

--- a/releng/org.openhwgroup.corev.ide.aggregator/pom.xml
+++ b/releng/org.openhwgroup.corev.ide.aggregator/pom.xml
@@ -17,8 +17,8 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.openhwgroup.corev.ide.cdt</groupId>
-	<artifactId>org.openhwgroup.corev.ide.cdt.aggregator</artifactId>
+	<groupId>org.openhwgroup.corev.ide</groupId>
+	<artifactId>org.openhwgroup.corev.ide.aggregator</artifactId>
 	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 

--- a/releng/org.openhwgroup.corev.ide.parent/pom.xml
+++ b/releng/org.openhwgroup.corev.ide.parent/pom.xml
@@ -17,8 +17,8 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.openhwgroup.corev.ide.cdt</groupId>
-	<artifactId>org.openhwgroup.corev.ide.cdt.parent</artifactId>
+	<groupId>org.openhwgroup.corev.ide</groupId>
+	<artifactId>org.openhwgroup.corev.ide.parent</artifactId>
 	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
The additional "cdt" postfix seems unnecessary, other platforms most
probably will use another programming technology anyway.

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>