### PR TITLE
#13 Change branding to CORE-V IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-<img src="https://www.openhwgroup.org/images/openhw-landscape.svg" width="418px" height="103px" />
-
-## OpenHW Group Core-V IDE based on Eclipse CDT
+<img src="https://www.openhwgroup.org/images/openhw-landscape.svg" width="418px" height="103px" /> <img src="https://www.openhwgroup.org/images/core-v-portrait.png" align="right" width="150px" height="120px"/>
+## OpenHW Group CORE-V IDE based on Eclipse CDT
 
 [![Eclipse License](https://img.shields.io/badge/license-EPL--2.0-brightgreen.svg)](https://github.com/openhwgroup/core-v-ide-cdt/blob/master/LICENSE)
 [![Build Status](https://github.com/openhwgroup/core-v-ide-cdt/workflows/CI/badge.svg)](https://github.com/openhwgroup/core-v-ide-cdt/actions)

--- a/bundles/org.openhwgroup.corev.ide/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.openhwgroup.corev.ide/OSGI-INF/l10n/bundle.properties
@@ -12,11 +12,11 @@
 #     Alexander Fedorov (ArSysOp) - initial API and implementation
 ###############################################################################
 
-Bundle-Name = OpenHW Group Core-V IDE
+Bundle-Name = OpenHW Group CORE-V IDE
 Bundle-Vendor = OpenHW Group
 
-productName=OpenHW IDE
-productBlurb=OpenHW IDE\n\
+productName=CORE-V IDE
+productBlurb=CORE-V IDE\n\
 \n\
 Version: {0}\n\
 \n\

--- a/bundles/org.openhwgroup.corev.ide/about.properties
+++ b/bundles/org.openhwgroup.corev.ide/about.properties
@@ -11,7 +11,7 @@
 #     Alexander Fedorov (ArSysOp) - initial API and implementation
 ###############################################################################
 
-blurb=OpenHW IDE\n\
+blurb=CORE-V IDE\n\
 \n\
 Version: {featureVersion}\n\
 \n\

--- a/bundles/org.openhwgroup.corev.ide/plugin.xml
+++ b/bundles/org.openhwgroup.corev.ide/plugin.xml
@@ -6,7 +6,7 @@
          point="org.eclipse.core.runtime.products">
       <product
             application="org.eclipse.ui.ide.workbench"
-            name="OpenHW IDE">
+            name="CORE-V IDE">
          <property
                name="aboutImage"
                value="images\ohw_lg.png">

--- a/features/org.openhwgroup.corev.ide.cdt.feature/feature.properties
+++ b/features/org.openhwgroup.corev.ide.cdt.feature/feature.properties
@@ -12,7 +12,7 @@
 #     Alexander Fedorov (ArSysOp) - initial API and implementation
 ###############################################################################
 
-featureName=OpenHW Group Core-V IDE CDT
+featureName=OpenHW Group CORE-V IDE CDT
 providerName=OpenHW Group
-description=OpenHW Group Core-V IDE: Eclipse CDT integration
+description=OpenHW Group CORE-V IDE: Eclipse CDT integration
 copyright=Copyright (c) OpenHW Group and others.

--- a/features/org.openhwgroup.corev.ide.feature/feature.properties
+++ b/features/org.openhwgroup.corev.ide.feature/feature.properties
@@ -12,7 +12,7 @@
 #     Alexander Fedorov (ArSysOp) - initial API and implementation
 ###############################################################################
 
-featureName=OpenHW Group Core-V IDE
+featureName=OpenHW Group CORE-V IDE
 providerName=OpenHW Group
-description=OpenHW Group Core-V IDE based on Eclipse CDT
+description=OpenHW Group CORE-V IDE based on Eclipse CDT
 copyright=Copyright (c) OpenHW Group and others.

--- a/products/org.openhwgroup.corev.ide.product/org.openhwgroup.corev.ide.product.product
+++ b/products/org.openhwgroup.corev.ide.product/org.openhwgroup.corev.ide.product.product
@@ -13,7 +13,7 @@
 	Contributors:
 		Alexander Fedorov (ArSysOp) - initial API and implementation
 -->
-<product name="OpenHW IDE" uid="org.openhwgroup.corev.ide.product" id="org.openhwgroup.corev.ide.product" application="org.eclipse.ui.ide.workbench" version="0.1.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="CORE-V IDE" uid="org.openhwgroup.corev.ide.product" id="org.openhwgroup.corev.ide.product" application="org.eclipse.ui.ide.workbench" version="0.1.0.qualifier" useFeatures="true" includeLaunchers="true">
 
 
    <configIni use="default">

--- a/releng/org.openhwgroup.corev.ide.repository/category.xml
+++ b/releng/org.openhwgroup.corev.ide.repository/category.xml
@@ -22,9 +22,9 @@
 	</feature>
 	<category-def
 		name="org.openhwgroup.corev.ide.category"
-		label="OpenHW Group Core-V IDE">
+		label="OpenHW Group CORE-V IDE">
 		<description>
-			OpenHW Group Core-V IDE based on Eclipse CDT
+			OpenHW Group CORE-V IDE based on Eclipse CDT
 		</description>
 	</category-def>
 </site>


### PR DESCRIPTION
Changed
* "OpenHW IDE" -> "CORE-V IDE"
* "Core-V" -> "CORE-V"

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>