### PR TITLE
#18 Integrate CORE-V GCC-based toolchain

### DIFF
--- a/bundles/org.openhwgroup.corev.ide.toolchain.gnu/.classpath
+++ b/bundles/org.openhwgroup.corev.ide.toolchain.gnu/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.openhwgroup.corev.ide.toolchain.gnu/.project
+++ b/bundles/org.openhwgroup.corev.ide.toolchain.gnu/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhwgroup.corev.ide.toolchain.gnu</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhwgroup.corev.ide.toolchain.gnu/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhwgroup.corev.ide.toolchain.gnu/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhwgroup.corev.ide.toolchain.gnu/META-INF/MANIFEST.MF
+++ b/bundles/org.openhwgroup.corev.ide.toolchain.gnu/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: org.openhwgroup.corev.ide.toolchain.gnu
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.openhwgroup.corev.ide.toolchain.gnu
+Bundle-Version: 0.1.0.qualifier
+Bundle-Name: %Bundle-Name
+Bundle-Vendor: %Bundle-Vendor
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.openhwgroup.corev.ide.toolchain.gnu/OSGI-INF/l10n/bundle.properties
+++ b/bundles/org.openhwgroup.corev.ide.toolchain.gnu/OSGI-INF/l10n/bundle.properties
@@ -1,0 +1,16 @@
+#Properties file for org.openhwgroup.corev.ide.toolchain.gnu
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Alexander Fedorov (ArSysOp) - initial API and implementation
+###############################################################################
+
+Bundle-Vendor = OpenHW Group
+Bundle-Name = OpenHW Group CORE-V IDE GNU ToolChain

--- a/bundles/org.openhwgroup.corev.ide.toolchain.gnu/build.properties
+++ b/bundles/org.openhwgroup.corev.ide.toolchain.gnu/build.properties
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Alexander Fedorov (ArSysOp) - initial API and implementation
+###############################################################################
+
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/

--- a/releng/org.openhwgroup.corev.ide.aggregator/pom.xml
+++ b/releng/org.openhwgroup.corev.ide.aggregator/pom.xml
@@ -25,6 +25,7 @@
 	<modules>
 		<module>..\..\releng\org.openhwgroup.corev.ide.target</module>
 
+		<module>..\..\bundles\org.openhwgroup.corev.ide.toolchain.gnu</module>
 		<module>..\..\bundles\org.openhwgroup.corev.ide.debug.ui</module>
 		<module>..\..\features\org.openhwgroup.corev.ide.cdt.feature</module>
 


### PR DESCRIPTION
Add placeholder bundle "org.openhwgroup.corev.ide.toolchain.gnu" to use
for toolchain declaration

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>