### PR TITLE
#18 Integrate CORE-V GNU-based toolchain (by Embecosm)

### DIFF
--- a/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/.project
+++ b/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhwgroup.corev.ide.toolchain.gnu.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/build.properties
+++ b/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/build.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Alexander Fedorov (ArSysOp) - initial API and implementation
+###############################################################################
+
+bin.includes = feature.xml,\
+               feature.properties

--- a/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/feature.properties
+++ b/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/feature.properties
@@ -1,0 +1,18 @@
+#Properties file for org.openhwgroup.corev.ide.toolchain.gnu.feature
+###############################################################################
+# Copyright (c) 2020 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Alexander Fedorov (ArSysOp) - initial API and implementation
+###############################################################################
+
+featureName=OpenHW Group CORE-V IDE GNU Toolchain
+providerName=OpenHW Group
+description=OpenHW Group CORE-V IDE : GNU Toolchain support (by Embecosm)
+copyright=Copyright (c) OpenHW Group and others.

--- a/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/feature.xml
+++ b/features/org.openhwgroup.corev.ide.toolchain.gnu.feature/feature.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2020 ArSysOp and others
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	https://www.eclipse.org/legal/epl-2.0/.
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+		Alexander Fedorov (ArSysOp) - initial API and implementation
+-->
+<feature
+      id="org.openhwgroup.corev.ide.toolchain.gnu.feature"
+      label="%featureName"
+      version="0.1.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <plugin
+         id="org.openhwgroup.corev.ide.toolchain.gnu"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/products/org.openhwgroup.corev.ide.product/org.openhwgroup.corev.ide.product.product
+++ b/products/org.openhwgroup.corev.ide.product/org.openhwgroup.corev.ide.product.product
@@ -58,6 +58,7 @@
       <feature id="ilg.gnumcueclipse.packs.feature"/>
       <feature id="org.openhwgroup.corev.ide.cdt.feature"/>
       <feature id="org.openhwgroup.corev.ide.feature"/>
+      <feature id="org.openhwgroup.corev.ide.toolchain.gnu.feature"/>
    </features>
 
    <configurations>

--- a/releng/org.openhwgroup.corev.ide.aggregator/pom.xml
+++ b/releng/org.openhwgroup.corev.ide.aggregator/pom.xml
@@ -26,6 +26,8 @@
 		<module>..\..\releng\org.openhwgroup.corev.ide.target</module>
 
 		<module>..\..\bundles\org.openhwgroup.corev.ide.toolchain.gnu</module>
+		<module>..\..\features\org.openhwgroup.corev.ide.toolchain.gnu.feature</module>
+
 		<module>..\..\bundles\org.openhwgroup.corev.ide.debug.ui</module>
 		<module>..\..\features\org.openhwgroup.corev.ide.cdt.feature</module>
 

--- a/releng/org.openhwgroup.corev.ide.repository/category.xml
+++ b/releng/org.openhwgroup.corev.ide.repository/category.xml
@@ -20,6 +20,10 @@
 		id="org.openhwgroup.corev.ide.feature">
 		<category name="org.openhwgroup.corev.ide.category" />
 	</feature>
+	<feature
+		id="org.openhwgroup.corev.ide.toolchain.gnu.feature">
+		<category name="org.openhwgroup.corev.ide.category" />
+	</feature>
 	<category-def
 		name="org.openhwgroup.corev.ide.category"
 		label="OpenHW Group CORE-V IDE">


### PR DESCRIPTION
Add feature "org.openhwgroup.corev.ide.toolchain.gnu.feature" to
repository and product

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>